### PR TITLE
Read binary data as ArrayBuffer and DataURL

### DIFF
--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -1,0 +1,154 @@
+import Html exposing (Html, div, input, button, p, text, img)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick, onWithOptions)
+import StartApp
+import Effects exposing (Effects)
+import Task
+import FileReader exposing (readAsDataUrl, Error(..))
+import Json.Decode as Json exposing (..)
+
+type alias ImageData = Value
+
+type HoverState = 
+  Normal
+  | Hovering
+
+type alias Model = 
+  { hoverState : HoverState
+  , imageData: Maybe (ImageData)
+  , imageLoadError : Maybe (FileReader.Error)
+  } 
+
+init : Model
+init = Model Normal Nothing Nothing
+ 
+type alias NativeFile =
+  { name : String
+  , blob : Value    
+  }
+
+type Action = DragEnter
+  | DragLeave
+  | Drop (List NativeFile)
+  | LoadImageCompleted (Maybe Json.Value)
+--  | LoadImageFailed FileReader.Error
+
+
+onDragFunction : String -> Signal.Address a -> a -> Html.Attribute
+onDragFunction nativeEventName address payload =
+  onWithOptions nativeEventName {stopPropagation = False, preventDefault = True} Json.value (\_ -> Signal.message address payload)
+
+onDragEnter : Signal.Address a -> a -> Html.Attribute
+onDragEnter = onDragFunction "dragenter"
+
+onDragOver : Signal.Address a -> a -> Html.Attribute
+onDragOver = onDragFunction "dragover"
+
+onDragLeave : Signal.Address a -> a -> Html.Attribute
+onDragLeave = onDragFunction "dragleave"
+
+parseFilenameAt : Int -> Json.Decoder NativeFile
+parseFilenameAt index = Json.at ["dataTransfer", "files"] <|
+  Json.object2 NativeFile ((toString index) := (Json.object1 identity ("name" := Json.string))) (toString index := Json.value)
+
+parseFilenames : Int -> Json.Decoder (List NativeFile)
+parseFilenames count =
+ case count of
+    0 ->
+      succeed []
+    _ ->
+      Json.object2 (::) (parseFilenameAt (count - 1)) (parseFilenames (count - 1))
+  
+parseLength : Json.Decoder Int
+parseLength = Json.at ["dataTransfer", "files"] <| oneOf 
+  [ Json.object1 identity ("length" := Json.int)
+  , null 0 
+  ]
+
+onDrop : Signal.Address Action -> Html.Attribute
+onDrop address = onWithOptions "drop" {stopPropagation = True, preventDefault = True} (parseLength `andThen` parseFilenames) (\vals -> Signal.message address (Drop vals))
+
+update : Action -> Model -> (Model, Effects Action)
+update action model =
+    case action of
+      DragEnter -> ({model | hoverState = Hovering}, Effects.none)
+      DragLeave -> ({model | hoverState = Normal}, Effects.none)
+      Drop files -> ( {model | hoverState = Normal}, loadFirstFile files loadData)
+      LoadImageCompleted val -> ( {model | imageData = val}, Effects.none )
+
+-- VIEW
+
+view : Signal.Address Action -> Model -> Html
+view address model =
+    div 
+    [
+      countStyle model.hoverState
+      , onDragEnter address DragEnter
+      , onDragLeave address DragLeave
+      , onDragOver address DragEnter
+      , onDrop address
+    ]
+    [ text "Drop stuff here"
+    ]
+
+renderImageOrPrompt : Model -> Html
+renderImageOrPrompt model = 
+  case model.imageLoadError of
+    Just err -> text (errorMapper err)
+    Nothing -> case model.imageData of
+      Nothing -> text "Drop stuff here"
+      Just result -> img [property "src" result] []
+
+countStyle : HoverState -> Html.Attribute
+countStyle dragState =
+  style
+    [ ("font-size", "20px")
+    , ("font-family", "monospace")
+    , ("display", "block")
+    , ("width", "400px")
+    , ("height", "200px")
+    , ("text-align", "center")
+    , ("background", if (dragState == Hovering) then "#ffff99" else "#cccc99")
+    ]
+
+-- TASKS
+
+loadData : Json.Value -> Effects Action
+loadData file =
+    readAsDataUrl file
+        |> Task.toMaybe     
+        |> Task.map LoadImageCompleted
+        |> Effects.task
+
+loadFirstFile : List NativeFile -> (Json.Value -> Effects Action) -> Effects Action
+loadFirstFile files loader = 
+  let
+    maybeHead = List.head <| List.map .blob files
+  in
+    case maybeHead of
+      Nothing -> Effects.none
+      Just file -> loader file
+
+errorMapper : FileReader.Error -> String
+errorMapper err =
+    case err of
+        FileReader.ReadFail -> "File reading error"
+        FileReader.NoFileSpecified -> "No file specified"
+        FileReader.IdNotFound -> "Id Not Found"
+        FileReader.NoValidBlob -> "Give Blob was not valid"
+
+-- ----------------------------------
+app =
+    StartApp.start
+        { init = (init, Effects.none)
+        , update = update
+        , view = view
+        , inputs = []
+        }
+
+main =
+    app.html
+
+port tasks : Signal (Task.Task Effects.Never ())
+port tasks =
+    app.tasks

--- a/examples/Example.elm
+++ b/examples/Example.elm
@@ -46,6 +46,7 @@ errorMapper err =
         FileReader.ReadFail -> "File reading error"
         FileReader.NoFileSpecified -> "No file specified"
         FileReader.IdNotFound -> "Id Not Found"
+        FileReader.NoValidBlob -> "Give Blob was not valid"
 
 -- ----------------------------------
 app =

--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -12,11 +12,12 @@ import Task exposing (Task)
 import Native.FileReader
 import Json.Decode exposing (Value)
 
-{-| FileReader can fail in one of three cases:
+{-| FileReader can fail in one of four cases:
 
  - the Id specified in getTextFile does not match an input of type file in the document
+ - the blob passed in was not valid
  - no file has been chosen
- - the contents of the file cannot be read.
+ - the contents of the file cannot be read. 
 -}
 type Error
     = IdNotFound
@@ -32,8 +33,23 @@ to read the text file associated with it by the user.
 getTextFile : String -> Task Error String
 getTextFile = Native.FileReader.getTextFile
 
+{-| Takes a "File" or "Blob" JS object as a Json.Value 
+and starts a task to read the contents as an ArrayBuffer.
+The ArrayBuffer value returned in the Success case of the Task will
+be represented as a Json.Value to Elm.
+
+    getTextFile "upload"
+-}
 readAsArrayBuffer : Value -> Task Error Value
 readAsArrayBuffer = Native.FileReader.readAsArrayBuffer
 
+{-| Takes a "File" or "Blob" JS object as a Json.Value 
+and starts a task to read the contents as an DataURL (so it can
+be assigned to the src property of an img e.g.).
+The DataURL value returned in the Success case of the Task will
+be represented as a Json.Value to Elm.
+
+    getTextFile "upload"
+-}
 readAsDataUrl : Value -> Task Error Value
 readAsDataUrl = Native.FileReader.readAsDataUrl

--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -1,4 +1,4 @@
-module FileReader (Error(..), getTextFile) where
+module FileReader (Error(..), getTextFile, readAsArrayBuffer, readAsDataUrl) where
 {-| Elm bindings to HTML5 Reader API.
 
 # Read file as text string
@@ -10,6 +10,7 @@ import Signal
 import Task exposing (Task)
 
 import Native.FileReader
+import Json.Decode exposing (Value)
 
 {-| FileReader can fail in one of three cases:
 
@@ -19,6 +20,7 @@ import Native.FileReader
 -}
 type Error
     = IdNotFound
+    | NoValidBlob
     | NoFileSpecified
     | ReadFail
 
@@ -29,3 +31,9 @@ to read the text file associated with it by the user.
 -}
 getTextFile : String -> Task Error String
 getTextFile = Native.FileReader.getTextFile
+
+readAsArrayBuffer : Value -> Task Error Value
+readAsArrayBuffer = Native.FileReader.readAsArrayBuffer
+
+readAsDataUrl : Value -> Task Error Value
+readAsDataUrl = Native.FileReader.readAsDataUrl

--- a/src/Native/FileReader.js
+++ b/src/Native/FileReader.js
@@ -39,8 +39,59 @@ Elm.Native.FileReader.make = function(localRuntime){
             else callback(Task.fail({ctor : 'NoFileSpecified'}));
         });
     };
+    
+    // readAsArrayBuffer : Value -> Task error String
+    var readAsArrayBuffer = function(fileObjectToRead){
+        return Task.asyncFunction(function(callback){
+            var reader = new FileReader();
+
+            reader.onload = function(evt) {
+                return callback(Task.succeed(evt.target.result))
+            };
+
+            reader.onerror = function() {
+                return callback(Task.fail({ctor : 'ReadFail'}));
+            };
+
+            // specified field must be an <input type='file' ...>
+            // so it must exist and
+            // it must have a .files element
+            if (!fileObjectToRead || !(fileObjectToRead instanceof Blob)) {
+                return callback(Task.fail({ctor : 'NoValidBlob'}))
+            }
+
+            reader.readAsArrayBuffer(fileObjectToRead);            
+        });
+    };
+    
+    // readAsDataUrl : Value -> Task error String
+    var readAsDataUrl = function(fileObjectToRead){
+        return Task.asyncFunction(function(callback){
+            var reader = new FileReader();
+
+            reader.onload = function(evt) {
+                return callback(Task.succeed(evt.target.result))
+            };
+
+            reader.onerror = function() {
+                return callback(Task.fail({ctor : 'ReadFail'}));
+            };
+
+            // specified field must be an <input type='file' ...>
+            // so it must exist and
+            // it must have a .files element
+            if (!fileObjectToRead || !(fileObjectToRead instanceof Blob)) {
+                return callback(Task.fail({ctor : 'NoValidBlob'}))
+            }
+
+            reader.readAsDataURL(fileObjectToRead);            
+        });
+    };
+
 
     return {
-        getTextFile : getTextFile
+        getTextFile : getTextFile,
+        readAsArrayBuffer : readAsArrayBuffer,
+        readAsDataUrl: readAsDataUrl
     };
 };


### PR DESCRIPTION
Hi Simon,
thanks for Filereader, it's really useful! This PR is not yet ready for prime time but I wanted your input on how to improve it. 
I added an example that is a bit complex but covers the use case when you want to be able to let the user DnD files into the browser, extract them in Elm, and pass it into your library to get the contents, e.g. to load an image as a DataURL and assign it to an img src.
I have two major areas that I would like to improve but I am new to Elm and want to know what you think about it. 
1. The selection of the file source. You did it by passing a string that is a selector into getTextFile. I did it by passing a Json.Value into readAsDataUrl. I was thinking that we should instead pass in a function that returns the file object to be read and provide a helper function that turns a string selector into a helper function?
2. Should we create Elm wrapper types for the JS types ArrayBuffer, DataUrl and File? Right now they are all Json.Value but the signature would be much better if it were
readAsDataUrl : NativeFile -> Task Error DataUrl
or something like that, instead of
readAsDataUrl : Value -> Task Error Value.

Looking forward to your input! Also, I am new to Elm so please criticize everything else you see and don't like.
