### PR TITLE
Alternative DragDrop design, update of DataUrlExample

### DIFF
--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -37,13 +37,13 @@ update action model =
     case action of
       DnD (Drop files) ->
         ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter (Drop (Debug.log "drag" files)) model.dnDModel        
+          | dnDModel = DragDrop2.update dropAllowedFilter (Drop files) model.dnDModel        
           }
           , loadFirstFile files
         )
       DnD a ->
         ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter (Debug.log "drag" a) model.dnDModel          
+          | dnDModel = DragDrop2.update dropAllowedFilter a model.dnDModel          
           }
           , Effects.none
         )
@@ -65,7 +65,9 @@ update action model =
 
 dropAllowedFilter : List NativeFile -> Bool
 dropAllowedFilter files =
-  List.any dropAllowedForFile files
+  True
+  -- doesn't work ATM:
+  -- List.any dropAllowedForFile files
       
 dropAllowedForFile : NativeFile -> Bool
 dropAllowedForFile file =

--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -37,13 +37,13 @@ update action model =
     case action of
       DnD (Drop files) ->
         ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter (Drop files) model.dnDModel        
+          | dnDModel = DragDrop2.update dropAllowedFilter (Drop (Debug.log "drag" files)) model.dnDModel        
           }
           , loadFirstFile files
         )
       DnD a ->
         ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter a model.dnDModel          
+          | dnDModel = DragDrop2.update dropAllowedFilter (Debug.log "drag" a) model.dnDModel          
           }
           , Effects.none
         )
@@ -65,8 +65,7 @@ update action model =
 
 dropAllowedFilter : List NativeFile -> Bool
 dropAllowedFilter files =
-  True
-  --List.any dropAllowedForFile files
+  List.any dropAllowedForFile files
       
 dropAllowedForFile : NativeFile -> Bool
 dropAllowedForFile file =
@@ -133,7 +132,7 @@ loadFirstFile =
 
 loadData : FileRef -> Effects Action
 loadData file =
-    FileReader.readAsDataUrl (Debug.log "file" file)   -- will return a Task FileReader.Error Json.Value
+    FileReader.readAsDataUrl file   -- will return a Task FileReader.Error Json.Value
         |> Task.toResult -- gets turned into a Task Never (Result FileReader.Error Json.Value)
         |> Task.map LoadImageCompleted -- (turned into the LoadImageCompleted Action with the Result as a payload)
         |> Effects.task -- return as Effects Action
@@ -142,9 +141,9 @@ loadData file =
 loadFirstFileWithLoader : (FileRef -> Effects Action) -> List NativeFile -> Effects Action
 loadFirstFileWithLoader loader files =
   let
-    maybeHead = List.head <| List.map .blob files
+    maybeHead = List.head <| List.map .blob (List.filter dropAllowedForFile files) 
   in
-    case (Debug.log "head" maybeHead) of
+    case maybeHead of
       Nothing -> Effects.none
       Just file -> loader file
 

--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -36,14 +36,14 @@ update : Action -> Model -> (Model, Effects Action)
 update action model =
     case action of
       DnD (Drop files) ->
-        ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter (Drop files) model.dnDModel        
+        ( { model 
+          | dnDModel = DragDrop2.update (Drop files) model.dnDModel        
           }
           , loadFirstFile files
         )
       DnD a ->
         ( { model
-          | dnDModel = DragDrop2.update dropAllowedFilter a model.dnDModel          
+          | dnDModel = DragDrop2.update a model.dnDModel          
           }
           , Effects.none
         )
@@ -62,13 +62,7 @@ update action model =
           )
 
 -- VIEW
-
-dropAllowedFilter : List NativeFile -> Bool
-dropAllowedFilter files =
-  True
-  -- doesn't work ATM:
-  -- List.any dropAllowedForFile files
-      
+     
 dropAllowedForFile : NativeFile -> Bool
 dropAllowedForFile file =
   case file.mimeType of
@@ -100,10 +94,8 @@ renderImageOrPrompt model =
         case model.dnDModel of
           Normal ->
             text "Drop stuff here"
-          HoveringOk ->
+          Hovering ->
             text "Gimmie!"
-          HoveringRejected ->
-            text "I don't like files of this type"
       Just result -> 
         img [ property "src" result
           , property "max-width" (Json.Encode.string "100%")]
@@ -119,10 +111,8 @@ countStyle dragState =
     , ("height", "200px")
     , ("text-align", "center")
     , ("background", case dragState of
-                        DragDrop2.HoveringOk -> 
+                        DragDrop2.Hovering -> 
                             "#ffff99"
-                        DragDrop2.HoveringRejected -> 
-                            "#ff3333"
                         DragDrop2.Normal -> 
                             "#cccc99")
     ]

--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -4,120 +4,111 @@ import Html.Events exposing (onClick, onWithOptions)
 import StartApp
 import Effects exposing (Effects)
 import Task
-import FileReader exposing (readAsDataUrl, Error(..))
 import Json.Decode exposing (..)
 import Json.Encode
 
--- Model types
-type alias ImageData = Value
+import Json.Decode as Json exposing (Value, andThen)
 
-type HoverState
-  = Normal
-  | Hovering
+import FileReader exposing (FileRef, FileContentDataUrl, readAsTextFile, Error(..))
+import MimeHelpers exposing (MimeType(..))
+import DragDrop2 exposing (Action(Drop), dragDropEventHandlers, HoverState(..))
+import Decoders exposing (..)
+
+
+-- Model types
 
 type alias Model =
-  { hoverState : HoverState -- set to Hovering if the user is hovering with content over the drop zone
-  , imageData: Maybe (ImageData) -- the image data once it has been loaded
+  { dnDModel: DragDrop2.HoverState
+  , imageData: Maybe (FileContentDataUrl) -- the image data once it has been loaded
   , imageLoadError : Maybe (FileReader.Error) -- the Error in case loading failed
   }
 
 init : Model
-init = Model Normal Nothing Nothing
+init = Model DragDrop2.init Nothing Nothing
 
--- Helper type for the File JS object that is used when the user drops files into the DropZone with DnD
-type alias NativeFile =
-  { name : String
-  , blob : Value
-  }
-
-type Action = DragEnter -- user enters the drop zone while dragging something
-  | DragLeave -- user leaves drop zone
-  | Drop (List NativeFile) -- drop of a number of files
-  | LoadImageCompleted (Result FileReader.Error Json.Decode.Value) -- the loading of the file contents is complete
-
--- DnD handlers
-onDragFunction : String -> Signal.Address a -> a -> Html.Attribute
-onDragFunction nativeEventName address payload =
-  onWithOptions
-    nativeEventName
-    {stopPropagation = False, preventDefault = True}
-    Json.Decode.value
-    (\_ -> Signal.message address payload)
-
-onDragEnter : Signal.Address a -> a -> Html.Attribute
-onDragEnter = onDragFunction "dragenter"
-
-onDragOver : Signal.Address a -> a -> Html.Attribute
-onDragOver = onDragFunction "dragover"
-
-onDragLeave : Signal.Address a -> a -> Html.Attribute
-onDragLeave = onDragFunction "dragleave"
-
--- Json decoders for the somewhat weird drop eventdata structure
--- Int ????
-parseFilenameAt : Int -> Json.Decode.Decoder NativeFile
-parseFilenameAt index =
-    Json.Decode.at ["dataTransfer", "files"] <|
-      Json.Decode.object2
-        NativeFile
-        ((toString index) := (Json.Decode.object1 identity ("name" := Json.Decode.string)))
-        (toString index := Json.Decode.value)
-
-parseFilenames : Int -> Json.Decode.Decoder (List NativeFile)
-parseFilenames count =
-    case count of
-        0 ->
-          succeed []
-        _ ->
-          Json.Decode.object2 (::) (parseFilenameAt (count - 1)) (parseFilenames (count - 1))
-
-parseLength : Json.Decode.Decoder Int
-parseLength = Json.Decode.at ["dataTransfer", "files"] <| oneOf
-  [ Json.Decode.object1 identity ("length" := Json.Decode.int)
-  , null 0
-  ]
-
-onDrop : Signal.Address Action -> Html.Attribute
-onDrop address = onWithOptions "drop" {stopPropagation = True, preventDefault = True} (parseLength `andThen` parseFilenames) (\vals -> Signal.message address (Drop vals))
+type Action = 
+  DnD DragDrop2.Action
+  | LoadImageCompleted (Result FileReader.Error FileContentDataUrl) -- the loading of the file contents is complete
 
 -- UPDATE
 
 update : Action -> Model -> (Model, Effects Action)
 update action model =
     case action of
-      DragEnter -> ({model | hoverState = Hovering}, Effects.none)
-      DragLeave -> ({model | hoverState = Normal}, Effects.none)
-      Drop files -> ( {model | hoverState = Normal}, loadFirstFile files loadData)
+      DnD (Drop files) ->
+        ( { model
+          | dnDModel = DragDrop2.update dropAllowedFilter (Drop files) model.dnDModel        
+          }
+          , loadFirstFile files loadData
+        )
+      DnD a ->
+        ( { model
+          | dnDModel = DragDrop2.update dropAllowedFilter a model.dnDModel          
+          }
+          , Effects.none
+        )
       LoadImageCompleted result -> case result of
-        Result.Err err -> ( {model | imageLoadError = Just err}, Effects.none )
-        Result.Ok val -> ( {model | imageData = Just val}, Effects.none )
+        Result.Err err -> 
+          ( { model 
+            | imageLoadError = Just err
+            }
+            , Effects.none 
+          )
+        Result.Ok val -> 
+          ( { model 
+            | imageData = Just val
+            }
+            , Effects.none 
+          )
 
 -- VIEW
+
+dropAllowedFilter : List NativeFile -> Bool
+dropAllowedFilter files =
+  True
+  --List.any dropAllowedForFile files
+      
+dropAllowedForFile : NativeFile -> Bool
+dropAllowedForFile file =
+  case file.mimeType of
+    Nothing ->
+      False   
+    Just mimeType -> 
+      case mimeType of 
+        MimeHelpers.Image _ ->
+            True
+        _ ->
+            False
 
 view : Signal.Address Action -> Model -> Html
 view address model =
     div
-    [
-      countStyle model.hoverState
-      , onDragEnter address DragEnter
-      , onDragLeave address DragLeave
-      , onDragOver address DragEnter
-      , onDrop address
-    ]
+    (  countStyle model.dnDModel 
+    :: dragDropEventHandlers (Signal.forwardTo address DnD))    
     [ renderImageOrPrompt model
     ]
 
 renderImageOrPrompt : Model -> Html
 renderImageOrPrompt model =
   case model.imageLoadError of
-    Just err -> text (errorMapper err)
-    Nothing -> case model.imageData of
-      Nothing -> text "Drop stuff here"
-      Just result -> img [ property "src" result
-        , property "max-width" (Json.Encode.string "100%")]
-        []
+    Just err -> 
+      text (FileReader.toString err)
+    Nothing -> 
+      case model.imageData of
+      Nothing ->
+        case model.dnDModel of
+          Normal ->
+            text "Drop stuff here"
+          HoveringOk ->
+            text "Gimmie!"
+          HoveringRejected ->
+            text "I don't like files of this type"
+      Just result -> 
+        img [ property "src" result
+          , property "max-width" (Json.Encode.string "100%")]
+          []
 
-countStyle : HoverState -> Html.Attribute
+countStyle : DragDrop2.HoverState -> Html.Attribute
 countStyle dragState =
   style
     [ ("font-size", "20px")
@@ -126,34 +117,32 @@ countStyle dragState =
     , ("width", "400px")
     , ("height", "200px")
     , ("text-align", "center")
-    , ("background", if (dragState == Hovering) then "#ffff99" else "#cccc99")
+    , ("background", case dragState of
+                        DragDrop2.HoveringOk -> 
+                            "#ffff99"
+                        DragDrop2.HoveringRejected -> 
+                            "#ff3333"
+                        DragDrop2.Normal -> 
+                            "#cccc99")
     ]
 
 -- TASKS
-loadData : Json.Decode.Value -> Effects Action
+loadData : FileRef -> Effects Action
 loadData file =
-    readAsDataUrl file   -- will return a Task FileReader.Error Json.Value
+    FileReader.readAsDataUrl file   -- will return a Task FileReader.Error Json.Value
         |> Task.toResult -- gets turned into a Task Never (Result FileReader.Error Json.Value)
         |> Task.map LoadImageCompleted -- (turned into the LoadImageCompleted Action with the Result as a payload)
         |> Effects.task -- return as Effects Action
 
 -- small helper method to do nothing if 0 files were dropped, otherwise load the first file
-loadFirstFile : List NativeFile -> (Json.Decode.Value -> Effects Action) -> Effects Action
+loadFirstFile : List NativeFile -> (FileRef -> Effects Action) -> Effects Action
 loadFirstFile files loader =
   let
-    maybeHead = List.head <| List.map .blob files
+    maybeHead = List.head <| List.map .blob (List.filter dropAllowedForFile files)
   in
     case maybeHead of
       Nothing -> Effects.none
       Just file -> loader file
-
-errorMapper : FileReader.Error -> String
-errorMapper err =
-    case err of
-        FileReader.ReadFail -> "File reading error"
-        FileReader.NoFileSpecified -> "No file specified"
-        FileReader.IdNotFound -> "Id Not Found"
-        FileReader.NoValidBlob -> "Given Blob was not valid"
 
 -- ----------------------------------
 app =

--- a/examples/DataUrlExample.elm
+++ b/examples/DataUrlExample.elm
@@ -39,7 +39,7 @@ update action model =
         ( { model
           | dnDModel = DragDrop2.update dropAllowedFilter (Drop files) model.dnDModel        
           }
-          , loadFirstFile files loadData
+          , loadFirstFile files
         )
       DnD a ->
         ( { model
@@ -127,20 +127,24 @@ countStyle dragState =
     ]
 
 -- TASKS
+loadFirstFile : List NativeFile -> Effects Action
+loadFirstFile =
+  loadFirstFileWithLoader loadData
+
 loadData : FileRef -> Effects Action
 loadData file =
-    FileReader.readAsDataUrl file   -- will return a Task FileReader.Error Json.Value
+    FileReader.readAsDataUrl (Debug.log "file" file)   -- will return a Task FileReader.Error Json.Value
         |> Task.toResult -- gets turned into a Task Never (Result FileReader.Error Json.Value)
         |> Task.map LoadImageCompleted -- (turned into the LoadImageCompleted Action with the Result as a payload)
         |> Effects.task -- return as Effects Action
 
 -- small helper method to do nothing if 0 files were dropped, otherwise load the first file
-loadFirstFile : List NativeFile -> (FileRef -> Effects Action) -> Effects Action
-loadFirstFile files loader =
+loadFirstFileWithLoader : (FileRef -> Effects Action) -> List NativeFile -> Effects Action
+loadFirstFileWithLoader loader files =
   let
-    maybeHead = List.head <| List.map .blob (List.filter dropAllowedForFile files)
+    maybeHead = List.head <| List.map .blob files
   in
-    case maybeHead of
+    case (Debug.log "head" maybeHead) of
       Nothing -> Effects.none
       Just file -> loader file
 

--- a/src/DragDrop2.elm
+++ b/src/DragDrop2.elm
@@ -23,8 +23,7 @@ import Decoders exposing (..)
 
 type HoverState
     = Normal
-    | HoveringOk
-    | HoveringRejected
+    | Hovering
 
 type alias Model = HoverState -- set to Hovering if the user is hovering with content over the drop zone    
 
@@ -34,18 +33,15 @@ init = Normal
 -- UPDATE
 
 type Action
-    = DragEnter (List NativeFile) -- user enters the drop zone while dragging something
+    = DragEnter -- user enters the drop zone while dragging something
     | DragLeave -- user leaves drop zone
     | Drop (List NativeFile)
 
-update : (List NativeFile -> Bool) -> Action -> Model -> Model
-update dropAllowedFilter action model =
+update : Action -> Model -> Model
+update action model =
     case action of
-        DragEnter files ->
-            if (dropAllowedFilter files) then 
-              HoveringOk
-            else
-              HoveringRejected
+        DragEnter ->
+            Hovering            
         DragLeave ->
             Normal            
         Drop files ->
@@ -54,9 +50,9 @@ update dropAllowedFilter action model =
 -- View event handlers
 dragDropEventHandlers : Signal.Address Action -> List Attribute
 dragDropEventHandlers address =
-    [ onDragEnter address
+    [ onDragEnter address DragEnter
     , onDragLeave address DragLeave
-    , onDragOver address
+    , onDragOver address DragEnter
     , onDrop address
     ]
 
@@ -77,13 +73,13 @@ onDragFunctionDecodeFiles nativeEventName actionCreator address =
         (parseLength `andThen` parseFilenames)
         (\vals -> Signal.message address (actionCreator vals))
 
-onDragEnter : Signal.Address Action -> Attribute
-onDragEnter address = 
-  onDragFunctionDecodeFiles "dragenter" (\files -> DragEnter files) address 
+onDragEnter : Signal.Address a -> a -> Attribute
+onDragEnter = 
+  onDragFunctionIgnoreFiles "dragenter"
 
-onDragOver : Signal.Address Action -> Attribute
-onDragOver address = 
-  onDragFunctionDecodeFiles "dragover" (\files -> DragEnter files) address 
+onDragOver : Signal.Address a -> a -> Attribute
+onDragOver = 
+  onDragFunctionIgnoreFiles "dragover"
 
 onDragLeave : Signal.Address a -> a -> Attribute
 onDragLeave = 

--- a/src/DragDrop2.elm
+++ b/src/DragDrop2.elm
@@ -1,0 +1,96 @@
+{-
+Based on original code from Daniel Bachler (danyx23)
+-}
+
+module DragDrop2 
+  ( HoverState(..)
+  , Action(Drop)
+  , init
+  , update
+  , dragDropEventHandlers
+  ) where
+
+import Html exposing (Html, Attribute, div, text)
+-- import Html.Attributes exposing (..)
+import Html.Events exposing (onWithOptions)
+
+import Json.Decode as Json exposing (andThen)
+import Effects exposing (Effects)
+
+import Decoders exposing (..)
+
+-- MODEL
+
+type HoverState
+    = Normal
+    | HoveringOk
+    | HoveringRejected
+
+type alias Model = HoverState -- set to Hovering if the user is hovering with content over the drop zone    
+
+init : Model
+init = Normal
+
+-- UPDATE
+
+type Action
+    = DragEnter (List NativeFile) -- user enters the drop zone while dragging something
+    | DragLeave -- user leaves drop zone
+    | Drop (List NativeFile)
+
+update : (List NativeFile -> Bool) -> Action -> Model -> Model
+update dropAllowedFilter action model =
+    case action of
+        DragEnter files ->
+            if (dropAllowedFilter files) then 
+              HoveringOk
+            else
+              HoveringRejected
+        DragLeave ->
+            Normal            
+        Drop files ->
+            Normal
+
+-- View event handlers
+dragDropEventHandlers : Signal.Address Action -> List Attribute
+dragDropEventHandlers address =
+    [ onDragEnter address
+    , onDragLeave address DragLeave
+    , onDragOver address
+    , onDrop address
+    ]
+
+-- Individual handler functions
+onDragFunctionIgnoreFiles : String -> Signal.Address a -> a -> Attribute
+onDragFunctionIgnoreFiles nativeEventName address action =
+    onWithOptions
+        nativeEventName
+        {stopPropagation = False, preventDefault = True}
+        Json.value
+        (\_ -> Signal.message address action)
+
+onDragFunctionDecodeFiles : String -> (List NativeFile -> Action) -> Signal.Address Action -> Html.Attribute
+onDragFunctionDecodeFiles nativeEventName actionCreator address =
+    onWithOptions
+        nativeEventName
+        {stopPropagation = True, preventDefault = True}
+        (parseLength `andThen` parseFilenames)
+        (\vals -> Signal.message address (actionCreator vals))
+
+onDragEnter : Signal.Address Action -> Attribute
+onDragEnter address = 
+  onDragFunctionDecodeFiles "dragenter" (\files -> DragEnter files) address 
+
+onDragOver : Signal.Address Action -> Attribute
+onDragOver address = 
+  onDragFunctionDecodeFiles "dragenter" (\files -> DragEnter files) address 
+
+onDragLeave : Signal.Address a -> a -> Attribute
+onDragLeave = 
+  onDragFunctionIgnoreFiles "dragleave"
+
+onDrop : Signal.Address Action -> Html.Attribute
+onDrop address =
+  onDragFunctionDecodeFiles "drop" (\files -> Drop files) address 
+
+

--- a/src/DragDrop2.elm
+++ b/src/DragDrop2.elm
@@ -83,7 +83,7 @@ onDragEnter address =
 
 onDragOver : Signal.Address Action -> Attribute
 onDragOver address = 
-  onDragFunctionDecodeFiles "dragenter" (\files -> DragEnter files) address 
+  onDragFunctionDecodeFiles "dragover" (\files -> DragEnter files) address 
 
 onDragLeave : Signal.Address a -> a -> Attribute
 onDragLeave = 

--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -1,11 +1,13 @@
 module FileReader
     ( FileRef
+    , FileContentArrayBuffer
+    , FileContentDataUrl
     , Error(..)
     , getTextFile
     , readAsTextFile
     , readAsArrayBuffer
     , readAsDataUrl
-    , toString
+    , toString    
     ) where
 
 {-| Elm bindings to HTML5 Reader API.
@@ -22,6 +24,8 @@ import Native.FileReader
 import Json.Decode exposing (Value)
 
 type alias FileRef = Value
+type alias FileContentArrayBuffer = Value
+type alias FileContentDataUrl = Value
 {-| FileReader can fail in one of four cases:
 
  - the Id specified in getTextFile does not match an input of type file in the document
@@ -58,7 +62,7 @@ be represented as a Json.Value to Elm.
 
     readAsArrayBuffer val
 -}
-readAsArrayBuffer : Value -> Task Error Value
+readAsArrayBuffer : FileRef -> Task Error FileContentArrayBuffer
 readAsArrayBuffer = Native.FileReader.readAsArrayBuffer
 
 {-| Takes a "File" or "Blob" JS object as a Json.Value
@@ -69,7 +73,7 @@ be represented as a Json.Value to Elm.
 
     readAsDataUrl val
 -}
-readAsDataUrl : Value -> Task Error Value
+readAsDataUrl : FileRef -> Task Error FileContentDataUrl
 readAsDataUrl = Native.FileReader.readAsDataUrl
 
 


### PR DESCRIPTION
Hi Simon,

I finished updating the DataUrlExample to your changes. I also implemented a smaller DragDrop design that does not provide it's own view as we discussed before.

I have not touched your examples yet to make the use the new DragDrop2 as I guess we will remove the old one and rename the new to DragDrop. If you like, I can change your examples to work with the new API, but I didn't want to touch them while you are still working on them.

What do you think? As always, please feel free to criticize my code, I feel like I am still a bit clumsy with Elm at times and I very much value your input.
