### PR TITLE
fixes examples build

### DIFF
--- a/examples/DragDrop.elm
+++ b/examples/DragDrop.elm
@@ -11,7 +11,7 @@ module DragDrop
   ) where
 
 -- import Effects exposing (Effects)
--- import Html exposing (Html, Attribute, div, text)
+import Html exposing (Attribute)
 import Html.Events exposing (onWithOptions)
 import Json.Decode as Json
 

--- a/examples/Ex2-DD-text.elm
+++ b/examples/Ex2-DD-text.elm
@@ -1,15 +1,11 @@
 import Html exposing (Html, div, input, button, h1, p, text)
 import Html.Attributes exposing (type', id, style)
-import Html.Events exposing (onClick, on)
 import StartApp
 import Effects exposing (Effects)
 import Task
 
-import Json.Decode as Json exposing (Value, andThen)
-
 import FileReader exposing (FileRef, NativeFile, readAsTextFile, Error(..))
 import DragDrop exposing (Action(Drop), dragDropEventHandlers)
-import MimeHelpers exposing (MimeType(Text))
 
 -- MODEL
 

--- a/examples/Ex3-DD-DataUrl.elm
+++ b/examples/Ex3-DD-DataUrl.elm
@@ -1,18 +1,12 @@
 import Html exposing (Html, div, input, button, p, text, img)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onWithOptions)
 import StartApp
 import Effects exposing (Effects)
 import Task
-import Json.Decode exposing (..)
-import Json.Encode
-
-import Json.Decode as Json exposing (Value, andThen)
 
 import FileReader exposing (..)
-import MimeHelpers exposing (MimeType(..))
+import MimeType exposing (MimeType(..))
 import DragDrop exposing (Action(Drop), dragDropEventHandlers, HoverState(..))
--- import Decoders exposing (..)
 
 
 -- Model types
@@ -74,7 +68,7 @@ dropAllowedForFile file =
       False
     Just mimeType ->
       case mimeType of
-        MimeHelpers.Image _ ->
+        MimeType.Image _ ->
             True
         _ ->
             False


### PR DESCRIPTION
Removes some unused imports and renames MimeHelpers to MimeType.
Also imports Html Attributes again in DnD.
