### PR TITLE
Add creation of body of arbitrary binary data.

### DIFF
--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -142,7 +142,7 @@ filePart name nf =
 -}
 rawBody : String -> NativeFile -> Body
 rawBody mimeType nf =
-    Native.FileReader.filePart mimeType nf.blob
+    Native.FileReader.rawBody mimeType nf.blob
     
 {-| Pretty print FileReader errors.
 

--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -12,6 +12,7 @@ module FileReader
         , parseSelectedFiles
         , parseDroppedFiles
         , filePart
+        , rawBody
         )
 
 {-| Elm bindings for the main [HTML5 FileReader APIs](https://developer.mozilla.org/en/docs/Web/API/FileReader):
@@ -137,7 +138,12 @@ filePart : String -> NativeFile -> Part
 filePart name nf =
     Native.FileReader.filePart name nf.blob
 
-
+{-| Creates an Http.Body from a NativeFile, to support uploading of binary files without using multipart.
+-}
+rawBody : String -> NativeFile -> Body
+rawBody mimeType nf =
+    Native.FileReader.filePart mimeType nf.blob
+    
 {-| Pretty print FileReader errors.
 
     prettyPrint ReadFail   -- == "File reading error"

--- a/src/Native/FileReader.js
+++ b/src/Native/FileReader.js
@@ -54,10 +54,19 @@ var _simonh1000$file_reader$Native_FileReader = function() {
         }
     };
 
+    var rawBody = function (mimeType, blob) {
+        return {
+            ctor: "StringBody",
+            _0: mimeType,
+            _1: blob
+        };
+    };
+    
     return {
         readAsTextFile : readAsTextFile,
         readAsArrayBuffer : readAsArrayBuffer,
         readAsDataUrl: readAsDataUrl,
-        filePart: F2(filePart)
+        filePart: F2(filePart),
+        rawBody: F2(rawBody)
     };
 }();


### PR DESCRIPTION
Applications using the "application/octet-stream" mime type, such as the Dropbox API, expect arbitrary binary data in a request body.

The `rawBody` function will allow this functionality in ELM by creating an Http.Body with binary content. 