### PR TITLE
Add base64 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 elm-stuff
 node_modules
 ignore
+.DS_Store

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.3.0",
+    "version": "1.3.1",
     "summary": "Elm bindings for HTML5 FileReader API",
-    "repository": "https://github.com/simonh1000/file-reader.git",
+    "repository": "https://github.com/outofboundstech/file-reader.git",
     "license": "BSD3",
     "source-directories": [
         "src"

--- a/src/FileReader.elm
+++ b/src/FileReader.elm
@@ -7,6 +7,7 @@ module FileReader
         , Error(..)
         , readAsTextFile
         , readAsArrayBuffer
+        , readAsBase64
         , readAsDataUrl
         , prettyPrint
         , parseSelectedFiles
@@ -112,6 +113,10 @@ readAsArrayBuffer : FileRef -> Task Error FileContentArrayBuffer
 readAsArrayBuffer fileRef =
     Native.FileReader.readAsArrayBuffer fileRef
 
+
+readAsBase64 : FileRef -> Task Error String
+readAsBase64 fileRef =
+    Native.FileReader.readAsBase64 fileRef
 
 {-| Takes a "File" or "Blob" JS object as a Json.Value
 and starts a task to read the contents as an DataURL (so it can

--- a/src/Native/FileReader.js
+++ b/src/Native/FileReader.js
@@ -1,9 +1,9 @@
-var _user$project$Native_FileReader = function() {
-// var _simonh1000$file_reader$Native_FileReader = function() {
+// var _user$project$Native_FileReader = function() {
+var _outofboundstech$file_reader$Native_FileReader = function() {
 
     var scheduler = _elm_lang$core$Native_Scheduler;
 
-    function useReader(method, fileObjectToRead) {
+    function useReader(method, fileObjectToRead, as_base64=false) {
         return scheduler.nativeBinding(function(callback){
 
             /*
@@ -16,7 +16,12 @@ var _user$project$Native_FileReader = function() {
             var reader = new FileReader();
 
             reader.onload = function(evt) {
-                return callback(scheduler.succeed(evt.target.result));
+                if (as_base64) {
+                    var uint8 = new Uint8Array(evt.target.result);
+                    return callback(scheduler.succeed(base64.fromByteArray(uint8)));
+                } else {
+                    return callback(scheduler.succeed(evt.target.result));
+                }
             };
 
             reader.onerror = function() {
@@ -49,6 +54,11 @@ var _user$project$Native_FileReader = function() {
         return useReader("readAsArrayBuffer", fileObjectToRead);
     };
 
+    // readAsArrayBuffer : Value -> Task error String
+    var readAsBase64 = function(fileObjectToRead){
+        return useReader("readAsArrayBuffer", fileObjectToRead, true);
+    };
+
     // readAsDataUrl : Value -> Task error String
     var readAsDataUrl = function(fileObjectToRead){
         return useReader("readAsDataURL", fileObjectToRead);
@@ -68,10 +78,11 @@ var _user$project$Native_FileReader = function() {
             _1: blob
         };
     };
-    
+
     return {
         readAsTextFile : readAsTextFile,
         readAsArrayBuffer : readAsArrayBuffer,
+        readAsBase64 : readAsBase64,
         readAsDataUrl: readAsDataUrl,
         filePart: F2(filePart),
         rawBody: F2(rawBody)


### PR DESCRIPTION
I have a use case whereby I want to read files as binary (ArrayBuffer) and immediately encode this contents as a base64 string. For this purpose I'm using the [base64-js](https://github.com/beatgammit/base64-js) library.

I could do a separate _round trip_ to vanilla javascript using either ports or another native elm module. Might it be an idea to support base64 encoding of binary file contents from the file-reader module out of the box?

I've implemented this use case on top of your existing code. I'm no expert at Elm native modules so my implementation might feel a bit _hackish_. For starters I'm assuming that base64-js is available in the global scope as `base64`. Do elm native modules support a AMD wrapper such as Require.js?