### PR TITLE
change from const to var

### DIFF
--- a/src/Native/FileReader.js
+++ b/src/Native/FileReader.js
@@ -31,7 +31,7 @@ var _simonh1000$file_reader$Native_FileReader = function() {
             }
 
             if (reader[method]) {
-                const result = reader[method](fileObjectToRead);
+                var result = reader[method](fileObjectToRead);
                 // prevent memory leak by nullifying fileObjectToRead
                 fileObjectToRead = null;
                 return result;


### PR DESCRIPTION
Due to const is not supported in safari 7 in both ios's safari and mac's safari.
When using elm that has elm-reader, it can't be used in safari 7 this change will make this work on safari 7 also both mac os and ios ones.

Thank you.